### PR TITLE
Fix Address Balance API to Support Testnet and Signet

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -147,7 +147,7 @@ interface DeScribeCreateResponse {
 declare const getBitcoinNetwork: (network: typeof MAINNET | typeof TESTNET | typeof SIGNET | typeof REGTEST | typeof FRACTAL_TESTNET) => bitcoin.networks.Network;
 declare const findOrdinalsAddress: (addresses: any) => any;
 declare const findPaymentAddress: (addresses: any) => any;
-declare const getBTCBalance: (address: string) => Promise<number>;
+declare const getBTCBalance: (address: string, network: typeof MAINNET | typeof TESTNET | typeof SIGNET | typeof FRACTAL_TESTNET) => Promise<number>;
 declare const satoshisToBTC: (satoshis: number) => string;
 declare const isBase64: (str: string) => boolean;
 declare const isHex: (str: string) => boolean;

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -1,6 +1,7 @@
 import { FRACTAL_TESTNET, MAINNET, SIGNET, TESTNET } from "../consts/networks";
 export const MEMPOOL_SPACE_URL = "https://mempool.space";
 export const MEMPOOL_SPACE_TESTNET_URL = "https://mempool.space/testnet";
+export const MEMPOOL_SPACE_SIGNET_URL = "https://mempool.space/signet/";
 
 export const getMempoolSpaceUrl = (
   network:
@@ -8,4 +9,27 @@ export const getMempoolSpaceUrl = (
     | typeof TESTNET
     | typeof SIGNET
     | typeof FRACTAL_TESTNET
-) => (network === TESTNET ? MEMPOOL_SPACE_TESTNET_URL : MEMPOOL_SPACE_URL);
+): string => {
+  switch (network) {
+    case MAINNET:
+      return MEMPOOL_SPACE_URL;
+    case TESTNET:
+      return MEMPOOL_SPACE_TESTNET_URL;
+    case SIGNET:
+      return MEMPOOL_SPACE_SIGNET_URL;
+    default:
+      return MEMPOOL_SPACE_URL;
+  }
+};
+
+export const getMempoolApiAddressUrl = (
+  network:
+    | typeof MAINNET
+    | typeof TESTNET
+    | typeof SIGNET
+    | typeof FRACTAL_TESTNET,
+  address: string
+): string => {
+  const baseUrl = getMempoolSpaceUrl(network);
+  return `${baseUrl}/api/address/${address}`;
+};

--- a/src/providers/LaserEyesProvider.tsx
+++ b/src/providers/LaserEyesProvider.tsx
@@ -395,7 +395,7 @@ const LaserEyesProvider = ({
             setLibrary((window as any).BitcoinProvider);
           }
 
-          getBTCBalance(foundPaymentAddress.address).then((totalBalance) => {
+          getBTCBalance(foundPaymentAddress.address, network).then((totalBalance) => {
             setBalance(totalBalance);
           });
         },
@@ -429,7 +429,7 @@ const LaserEyesProvider = ({
       setProvider(OYL);
       handleAccountsChanged(result);
       setConnected(true);
-      getBTCBalance(result[1]).then((totalBalance) => {
+      getBTCBalance(result[1], network).then((totalBalance) => {
         setBalance(totalBalance);
       });
     } catch (error) {
@@ -463,7 +463,7 @@ const LaserEyesProvider = ({
             setLibrary((window as any).magicEden.bitcoin);
           }
 
-          getBTCBalance(foundPaymentAddress.address).then((totalBalance) => {
+          getBTCBalance(foundPaymentAddress.address, network).then((totalBalance) => {
             setBalance(totalBalance);
           });
         },
@@ -543,7 +543,7 @@ const LaserEyesProvider = ({
       setPaymentPublicKey(String(segwitAddress?.publicKey));
       setLibrary(lib);
       setProvider(LEATHER);
-      const balance = await getBTCBalance(String(segwitAddress?.address));
+      const balance = await getBTCBalance(String(segwitAddress?.address), network);
       setBalance(balance);
       handleAccountsChanged(leatherAccountsParsed);
       setConnected(true);
@@ -585,7 +585,7 @@ const LaserEyesProvider = ({
       setPaymentPublicKey(paymentAccount?.publicKey!);
       setLibrary(lib);
       setProvider(PHANTOM);
-      const balance = await getBTCBalance(String(paymentAccount?.address!));
+      const balance = await getBTCBalance(String(paymentAccount?.address!), network);
       setBalance(balance);
       setConnected(true);
     } catch (error) {
@@ -909,18 +909,18 @@ const LaserEyesProvider = ({
       if (provider === UNISAT) {
         return await library.getBalance();
       } else if (provider === XVERSE) {
-        return await getBTCBalance(paymentAddress);
+        return await getBTCBalance(paymentAddress, network);
       } else if (provider === OYL) {
         const balanceResponse: OYLBalanceResponse = await library.getBalance();
         return balanceResponse.btc.total * 100000000;
       } else if (provider === MAGIC_EDEN) {
-        return await getBTCBalance(paymentAddress);
+        return await getBTCBalance(paymentAddress, network);
       } else if (provider === OKX) {
-        return await getBTCBalance(paymentAddress);
+        return await getBTCBalance(paymentAddress, network);
       } else if (provider === LEATHER) {
-        return await getBTCBalance(paymentAddress);
+        return await getBTCBalance(paymentAddress, network);
       } else if (provider === PHANTOM) {
-        return await getBTCBalance(paymentAddress);
+        return await getBTCBalance(paymentAddress, network);
       } else if (provider === WIZZ) {
         const balanceResponse: WizzBalanceResponse = await library.getBalance();
         return balanceResponse.total * 100000000;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -218,3 +218,21 @@ export interface Status {
   block_hash: string;
   block_time: number;
 }
+
+export type AddressStats = {
+  address: string;
+  chain_stats: {
+    funded_txo_count: number;
+    funded_txo_sum: number;
+    spent_txo_count: number;
+    spent_txo_sum: number;
+    tx_count: number;
+  };
+  mempool_stats: {
+    funded_txo_count: number;
+    funded_txo_sum: number;
+    spent_txo_count: number;
+    spent_txo_sum: number;
+    tx_count: number;
+  };
+};


### PR DESCRIPTION
Fixed an issue where the service failed to fetch the BTC balance for testnet addresses due to the Blockchain.info API not supporting testnet addresses. Updated the implementation to use an alternative API that supports testnet addresses.

This is a response to this issue #38 

Changes:
- Replaced the Blockchain.info API endpoint with a suitable alternative for testnet support [mempool](mempool.space).
- Ensured the solution handles both mainnet and testnet addresses correctly.

This fix resolves the error encountered when connected to testnet and ensures compatibility with testnet address queries. Please review the changes and provide feedback if further adjustments are required.