### PR TITLE
[Fix] createSendBtcPsbt - Remove extra `amount` substraction from change output

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -198,7 +198,7 @@ export async function createSendBtcPsbt(
   if (amountGathered > satsNeeded) {
     psbt.addOutput({
       address: paymentAddress,
-      value: amountGathered - satsNeeded - amount,
+      value: amountGathered - satsNeeded,
     });
   }
 


### PR DESCRIPTION
Ref issue: #52 

Removed the extra `amount` substraction from the change output value calculation, as `amount` is already included as part of `satsNeeded`, leading to negative numbers, or the sender not getting back the change they are supposed to.

As I can see, this is only an issue if you use the `createSendBtcPsbt` function through the library, or use it with OYL Wallet.

